### PR TITLE
Potential fix for code scanning alert no. 25: Server-side request forgery

### DIFF
--- a/backend/src/api/acceleration/acceleration.routes.ts
+++ b/backend/src/api/acceleration/acceleration.routes.ts
@@ -39,7 +39,20 @@ class AccelerationRoutes {
   }
 
   private async $getAcceleratorAccelerationsHistoryAggregated(req: Request, res: Response): Promise<void> {
-    const url = `${config.MEMPOOL_SERVICES.API}/${req.originalUrl.replace('/api/v1/services/', '')}`;
+    const allowedPaths = {
+      'accelerations': 'accelerations',
+      'accelerations/history': 'accelerations/history',
+      'accelerations/stats': 'accelerations/stats',
+      'estimate': 'estimate',
+    };
+    const userPath = req.originalUrl.replace('/api/v1/services/', '');
+    const safePath = allowedPaths[userPath];
+    if (!safePath) {
+      logger.err(`Invalid path requested: ${userPath}`, this.tag);
+      res.status(400).send({ error: 'Invalid path' });
+      return;
+    }
+    const url = `${config.MEMPOOL_SERVICES.API}/${safePath}`;
     try {
       const response = await axios.get(url, { responseType: 'stream', timeout: 10000 });
       for (const key in response.headers) {
@@ -67,7 +80,20 @@ class AccelerationRoutes {
   }
 
   private async $getAcceleratorEstimate(req: Request, res: Response): Promise<void> {
-    const url = `${config.MEMPOOL_SERVICES.API}/${req.originalUrl.replace('/api/v1/services/', '')}`;
+    const allowedPaths = {
+      'accelerations': 'accelerations',
+      'accelerations/history': 'accelerations/history',
+      'accelerations/stats': 'accelerations/stats',
+      'estimate': 'estimate',
+    };
+    const userPath = req.originalUrl.replace('/api/v1/services/', '');
+    const safePath = allowedPaths[userPath];
+    if (!safePath) {
+      logger.err(`Invalid path requested: ${userPath}`, this.tag);
+      res.status(400).send({ error: 'Invalid path' });
+      return;
+    }
+    const url = `${config.MEMPOOL_SERVICES.API}/${safePath}`;
     try {
       const response = await axios.post(url, req.body, { responseType: 'stream', timeout: 10000 });
       for (const key in response.headers) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/mempool/security/code-scanning/25](https://github.com/Dargon789/mempool/security/code-scanning/25)

To fix the SSRF vulnerability, we need to ensure that user input (`req.originalUrl`) is validated and sanitized before being used to construct the `url`. Specifically:
1. Restrict the user input to a predefined set of allowed paths or endpoints using an allow-list.
2. Ensure that the constructed `url` does not allow path traversal or other manipulations that could redirect the request to unintended endpoints.

The best approach is to use an allow-list to map user input to known, safe paths. This ensures that the outgoing request is limited to trusted endpoints.

Changes to make:
- Introduce an allow-list of valid paths or endpoints.
- Replace the direct use of `req.originalUrl.replace('/api/v1/services/', '')` with a lookup in the allow-list.
- Reject requests with invalid or unrecognized paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate and sanitize user-supplied paths in acceleration service routes to prevent SSRF by using an allow-list and rejecting invalid requests.

Bug Fixes:
- Fix SSRF vulnerability in acceleration routes by replacing direct use of user-controlled URLs with allow-listed paths.

Enhancements:
- Introduce an allow-list of valid service endpoints for acceleration history, stats, and estimate.
- Add logging and return HTTP 400 for requests with invalid or unrecognized paths.