### PR TITLE
Potential fix for code scanning alert no. 24: Server-side request forgery

### DIFF
--- a/backend/src/api/acceleration/acceleration.routes.ts
+++ b/backend/src/api/acceleration/acceleration.routes.ts
@@ -66,7 +66,20 @@ class AccelerationRoutes {
   }
 
   private async $getAcceleratorAccelerationsStats(req: Request, res: Response): Promise<void> {
-    const url = `${config.MEMPOOL_SERVICES.API}/${req.originalUrl.replace('/api/v1/services/', '')}`;
+    const allowedPaths = {
+      'accelerations': 'accelerations',
+      'accelerations/history': 'accelerations/history',
+      'accelerations/stats': 'accelerations/stats',
+      'estimate': 'estimate',
+    };
+    const userPath = req.originalUrl.replace('/api/v1/services/', '');
+    const safePath = allowedPaths[userPath];
+    if (!safePath) {
+      logger.err(`Invalid path requested: ${userPath}`, this.tag);
+      res.status(400).send({ error: 'Invalid path' });
+      return;
+    }
+    const url = `${config.MEMPOOL_SERVICES.API}/${safePath}`;
     try {
       const response = await axios.get(url, { responseType: 'stream', timeout: 10000 });
       for (const key in response.headers) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/mempool/security/code-scanning/24](https://github.com/Dargon789/mempool/security/code-scanning/24)

To fix this SSRF vulnerability, we must ensure that user-supplied data cannot arbitrarily control the target of the server-side HTTP request. As seen in other functions like `$getAcceleratorAccelerationsHistoryAggregated` and `$getAcceleratorEstimate`, the code uses an `allowedPaths` allow-list to restrict which paths may be proxied/fetched based on user input, mapping user-supplied input to a controlled, known set of API endpoints. We should replicate this pattern in `$getAcceleratorAccelerationsStats`.

Specifically:
- Add an `allowedPaths` mapping specifying valid relative API endpoints.
- Retrieve the requested path from the user's request, strip the `/api/v1/services/` prefix, and check if it exists in the allow-list.
- Only make the proxied request if the path is explicitly allowed; otherwise, return a 400 error.
- No change to imports is needed.
- Only lines within the `$getAcceleratorAccelerationsStats` method require editing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Restrict proxied requests in $getAcceleratorAccelerationsStats to an explicit allow-list of valid API paths and return 400 for invalid paths