### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete string escaping or encoding

### DIFF
--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.ts
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.ts
@@ -141,7 +141,7 @@ export class NodesPerISPChartComponent implements OnInit {
       }
       data.push({
         value: this.sortBy === 'capacity' ? isp[7] : isp[6],
-        name: isp[1].replace(/&/g, '') + (isMobile() || this.widget ? `` : ` (${this.sortBy === 'capacity' ? isp[7] : isp[6]}%)`),
+        name: (isp[1] || '').replace(/&/g, '') + (isMobile() || this.widget ? '' : ' (' + (this.sortBy === 'capacity' ? isp[7] : isp[6]) + '%)'),
         label: {
           overflow: 'truncate',
           width: isMobile() ? 75 : this.widget ? 125 : 250,

--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.ts
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.ts
@@ -141,7 +141,7 @@ export class NodesPerISPChartComponent implements OnInit {
       }
       data.push({
         value: this.sortBy === 'capacity' ? isp[7] : isp[6],
-        name: isp[1].replace('&', '') + (isMobile() || this.widget ? `` : ` (${this.sortBy === 'capacity' ? isp[7] : isp[6]}%)`),
+        name: isp[1].replace(/&/g, '') + (isMobile() || this.widget ? `` : ` (${this.sortBy === 'capacity' ? isp[7] : isp[6]}%)`),
         label: {
           overflow: 'truncate',
           width: isMobile() ? 75 : this.widget ? 125 : 250,


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/mempool/security/code-scanning/17](https://github.com/Dargon789/mempool/security/code-scanning/17)

Use a global replacement so all `&` characters are handled consistently.

Best minimal fix (no behavior change beyond correcting the bug): in `frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.ts`, update line 144 from string-based `replace` to regex-based global replace:
- From: `isp[1].replace('&', '')`
- To: `isp[1].replace(/&/g, '')`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incomplete removal of ampersand characters in ISP labels by applying the replacement globally.